### PR TITLE
security -> origin matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ oauth.authorize_path=/oauth/authorize
 oauth.token_path=/oauth/token
 ```
 
+For security reasons set an origin_pattern to match the origins, so that only trusted origins could be use to authenticate. Replace yoursite.com with your domain.
+```
+firebase functions:config:set oauth.origin_pattern="(^https://yoursite.com$|^https://www.yoursite.com$|^http://localhost:3000$)"
+```
+
 ### 4) Deploy the function
 Deploy the function to Firebase:
 ```

--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,7 @@
-{}
+{
+  "functions": {
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run lint"
+    ]
+  }
+}

--- a/functions/.eslintrc.json
+++ b/functions/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parserOptions": {
     // Required for certain syntax usages
-    "ecmaVersion": 6
+    "ecmaVersion": 8
   },
   "plugins": [
     "promise"

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,6 +11,11 @@ function getScript(mess, content) {
   (function() {
     function receiveMessage(e) {
       console.log("receiveMessage %o", e)
+      if (!e.origin.match(${JSON.stringify(oauth.origin_pattern,"i")})) {
+          console.log('Invalid origin: %s', e.origin);
+          window.close();
+          return;
+        }
       window.opener.postMessage(
         'authorization:github:${mess}:${JSON.stringify(content)}',
         e.origin
@@ -49,6 +54,10 @@ oauthApp.get('/auth', (req, res) => {
 })
 
 oauthApp.get('/callback', async (req, res) => {
+  if(''.match(oauth.origin_pattern || '')){
+    console.error("Insecure ORIGIN pattern used. This can give unauthorized users access to your repository.");
+    process.exit();
+  }
   var options = {
     code: req.query.code
   }
@@ -73,6 +82,7 @@ oauthApp.get('/callback', async (req, res) => {
     console.error('Access Token Error', error.message)
     res.send(getScript('error', error))
   }
+  return 'Error';
 })
 
 oauthApp.get('/success', (req, res) => {

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
I added:
1. Checking for origin and post token message only when e.origin matches the allowed origins.
2. Updated eslint version from 6 to 8 as async arrow function was throwing arrow during eslint checking.
3. Updated the readme file, describing how to set allowed origins.